### PR TITLE
Add an archival notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > [!IMPORTANT]  
 > New firmwares are released straight from the [SiLabs Firmware Builder repository](https://github.com/NabuCasa/silabs-firmware-builder/releases).
-> This repository contains all past firmwares and will not received future updates.
+> This repository contains all past firmwares and will not receive future updates.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]  
+> New firmwares are released straight from the [SiLabs Firmware Builder repository](https://github.com/NabuCasa/silabs-firmware-builder/releases).
+> This repository contains all past firmwares and will not received future updates.
+
+---
+
 # Silicon Labs firmware for Yellow and SkyConnect
 
 This repository contains firmware for products made by Nabu Casa


### PR DESCRIPTION
All future firmware releases will be released directly from https://github.com/NabuCasa/silabs-firmware-builder/releases.

<img width="1074" alt="image" src="https://github.com/NabuCasa/silabs-firmware/assets/32534428/0f7f0028-662b-487c-b941-d2d21d9790eb">
